### PR TITLE
Enable building on Linux

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
             ]
         }
     },
-    "postCreateCommand": "sudo apt-get update && apt-get install libsodium-dev -y",
+    "postCreateCommand": "sudo apt-get update && sudo apt-get install libsodium-dev -y",
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "Swift",
+    "image": "swift:6.0",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/go:1": {}
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "sswg.swift-lang"
+            ]
+        }
+    },
+    "postCreateCommand": "sudo apt-get update && apt-get install libsodium-dev -y",
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}

--- a/Sources/Nuid/Nuid.swift
+++ b/Sources/Nuid/Nuid.swift
@@ -50,14 +50,8 @@ public class Nuid {
         self.inc = MIN_INC + Int64.random(in: 0..<(MAX_INC - MIN_INC))
     }
 
-     func randomizePrefix() {
-        var cb = [UInt8](repeating: 0, count: PRE_LEN)
-        let result = SecRandomCopyBytes(kSecRandomDefault, PRE_LEN, &cb)
-
-        if result != errSecSuccess {
-            fatalError("nuid: failed generating crypto random number")
-        }
-
+    func randomizePrefix() {
+        let cb = SystemRandomNumberGenerator.randomBytes(count: PRE_LEN)
         for i in 0..<PRE_LEN {
             self.pre[i] = DIGITS[Int(cb[i]) % BASE]
         }

--- a/Sources/Nuid/RandomBytes.swift
+++ b/Sources/Nuid/RandomBytes.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension UnsafeMutableRawBufferPointer {
+    @inlinable
+    func initializeWithRandomBytes(count: Int) {
+        guard count > 0 else {
+            return
+        }
+
+        #if canImport(Darwin) || os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
+        var rng = SystemRandomNumberGenerator()
+        precondition(count <= self.count)
+
+        // We store bytes 64-bits at a time until we can't anymore.
+        var targetPtr = self
+        while targetPtr.count > 8 {
+            targetPtr.storeBytes(of: rng.next(), as: UInt64.self)
+            targetPtr = UnsafeMutableRawBufferPointer(rebasing: targetPtr[8...])
+        }
+
+        // Now we're down to having to store things an integer at a time. We do this by shifting and
+        // masking.
+        var remainingWord: UInt64 = rng.next()
+        while targetPtr.count > 0 {
+            targetPtr.storeBytes(of: UInt8(remainingWord & 0xFF), as: UInt8.self)
+            remainingWord >>= 8
+            targetPtr = UnsafeMutableRawBufferPointer(rebasing: targetPtr[1...])
+        }
+        #else
+        fatalError("No secure random number generator on this platform.")
+        #endif
+    }
+}
+
+extension SystemRandomNumberGenerator {
+    @inlinable
+    static func randomBytes(count: Int) -> [UInt8] {
+        Array(unsafeUninitializedCapacity: count) { buffer, initializedCount in
+            UnsafeMutableRawBufferPointer(start: buffer.baseAddress, count: buffer.count)
+                .initializeWithRandomBytes(count: count)
+            initializedCount = count
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I found your package was an upstream dependency in [nats](https://github.com/nats-io/nats.swift) that prevented building on Linux. I've updated it to use `SystemRandomNumberGenerator` and copied the required extensions from [apple/swift-crypto](https://github.com/apple/swift-crypto)